### PR TITLE
feat: Add create_post_comment MCP tool for esa.io

### DIFF
--- a/src/lib/esa/index.ts
+++ b/src/lib/esa/index.ts
@@ -1,5 +1,8 @@
 import path from "node:path";
 import {
+  type CreatePostCommentParams,
+  type CreatePostCommentResponse,
+  CreatePostCommentResponseSchema,
   type CreatePostParams,
   type CreatePostResponse,
   CreatePostResponseSchema,
@@ -106,6 +109,20 @@ export class Esa {
 
     const data = await response.json();
     return GetPostCommentsResponseSchema.parse(data);
+  }
+
+  async createPostComment(
+    params: CreatePostCommentParams,
+  ): Promise<CreatePostCommentResponse> {
+    const { post_number, ...commentParams } = params;
+    const response = await this._request({
+      path: `/v1/teams/${this._teamName}/posts/${post_number}/comments`,
+      method: "POST",
+      body: { comment: commentParams },
+    });
+
+    const data = await response.json();
+    return CreatePostCommentResponseSchema.parse(data);
   }
   private async _request(params: {
     path: string;

--- a/src/lib/esa/types.ts
+++ b/src/lib/esa/types.ts
@@ -221,6 +221,19 @@ export const GetPostCommentsResponseSchema = z.object({
   per_page: z.number(),
   max_per_page: z.number(),
 });
+
+export const CreatePostCommentParamsSchema = z.object({
+  post_number: z
+    .number()
+    .min(1)
+    .describe("Post number to comment on (required)."),
+  body_md: z
+    .string()
+    .min(1)
+    .describe("Comment content in Markdown format (required)."),
+});
+
+export const CreatePostCommentResponseSchema = CommentSchema;
 export type User = z.infer<typeof UserSchema>;
 export type Post = z.infer<typeof PostSchema>;
 export type Comment = z.infer<typeof CommentSchema>;
@@ -270,3 +283,9 @@ export type CreatePostResponse = z.infer<typeof CreatePostResponseSchema>;
 export type UpdatePostParams = z.infer<typeof UpdatePostParamsSchema>;
 export type UpdatePostResponse = z.infer<typeof UpdatePostResponseSchema>;
 export type DeletePostParams = z.infer<typeof DeletePostParamsSchema>;
+export type CreatePostCommentParams = z.infer<
+  typeof CreatePostCommentParamsSchema
+>;
+export type CreatePostCommentResponse = z.infer<
+  typeof CreatePostCommentResponseSchema
+>;

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Esa } from "../../lib/esa/index.js";
 import {
+  CreatePostCommentParamsSchema,
   CreatePostParamsSchema,
   DeletePostParamsSchema,
   GetPostCommentsParamsSchema,
@@ -62,6 +63,7 @@ export function registerTools(server: McpServer, esa: Esa) {
       };
     },
   );
+
   server.tool(
     "get_tags",
     "Get a list of all tags used in the esa team. Returns tags with their names and the number of posts they are attached to, sorted by post count in descending order. Supports pagination.",
@@ -102,6 +104,19 @@ export function registerTools(server: McpServer, esa: Esa) {
 
       return {
         content: [{ type: "text", text: JSON.stringify(comments) }],
+      };
+    },
+  );
+
+  server.tool(
+    "create_post_comment",
+    "Create a new comment on an existing post in the esa team. Requires a post number and comment content in Markdown format. Returns the created comment information including ID, content, timestamps, and author details.",
+    CreatePostCommentParamsSchema.shape,
+    async (params) => {
+      const comment = await esa.createPostComment(params);
+
+      return {
+        content: [{ type: "text", text: JSON.stringify(comment) }],
       };
     },
   );


### PR DESCRIPTION
## Summary

This PR adds a new MCP tool `create_post_comment` that enables creating comments on existing posts in esa.io through the MCP interface.

### Changes
- Add `CommentSchema` and `CreatePostCommentParamsSchema` to define comment data structure
- Implement `createPostComment` method in the Esa API client class
- Register `create_post_comment` tool in the MCP server with proper parameter validation
- Support required parameters: `post_number` and `body_md` (Markdown content)

### Features
- **Simple API**: Only requires post number and comment content in Markdown format
- **Type Safety**: Full TypeScript type definitions with Zod schema validation
- **Error Handling**: Proper error handling through the existing Esa client infrastructure
- **Consistent Interface**: Follows the same patterns as other MCP tools in the project

### Usage Example
```json
{
  "post_number": 123,
  "body_md": "LGTM\! This looks great 👍"
}
```

### API Endpoint
- **POST** `/v1/teams/{team}/posts/{post_number}/comments`
- Returns created comment with ID, content, timestamps, and author details

🤖 Generated with [Claude Code](https://claude.ai/code)