### PR TITLE
feat: Add --readonly flag for read-only mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,10 +74,12 @@ bun add -D <package-name>  # Development dependencies
 - `delete_post` - deletes post
 - `get_tags` - fetches all tags
 - `get_post_comments` - fetches comments for a post
+- `create_post_comment` - creates comment on post (write operation)
+
+#### CLI Options
+- `--readonly` - Enable read-only mode that only allows read operations (get_posts, get_post, get_tags, get_post_comments). Write operations (create_post, update_post, delete_post, create_post_comment) are disabled when this flag is used.
 
 #### TODO (from TODO file)
-- `--readonly` flag support
-- `create_post_comment` - create comment on post
 - `update_comment` - update existing comment
 - `delete_comment` - delete comment
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,39 @@ To use this server with an MCP client, add the following configuration:
 
 Replace `<your-team-name>` and `<your-personal-access-token>` with your team name and personal access token.
 
+#### Read-only Mode
+
+To enable read-only mode that only allows read operations, add the `--readonly` flag:
+
+```json
+{
+  "mcpServers": {
+    "esa-readonly": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "ESA_TEAM=<your-team-name>",
+        "-e",
+        "ESA_ACCESS_TOKEN=<your-personal-access-token>",
+        "ghcr.io/koki-develop/esa-mcp-server:latest",
+        "--readonly"
+      ]
+    }
+  }
+}
+```
+
+In read-only mode, only the following operations are available:
+- `get_posts` - retrieve posts
+- `get_post` - retrieve a specific post
+- `get_tags` - retrieve tags
+- `get_post_comments` - retrieve post comments
+
+Write operations (`create_post`, `update_post`, `delete_post`, `create_post_comment`) are disabled.
+
 ## MCP Tools
 
 - [Posts](#posts)

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
       "name": "mcp-server",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.13.0",
+        "commander": "14.0.0",
         "zod": "3.25.67",
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.13.0",
+    "commander": "14.0.0",
     "zod": "3.25.67"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,13 @@
+import { program } from "commander";
+import packageJson from "../package.json" with { type: "json" };
 import { runServer } from "./server";
 
-await runServer();
+program
+  .name("esa-mcp-server")
+  .description("MCP server for esa.io")
+  .version(packageJson.version)
+  .action(async () => {
+    await runServer();
+  });
+
+await program.parseAsync();

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,13 @@ program
   .name("esa-mcp-server")
   .description("MCP server for esa.io")
   .version(packageJson.version)
-  .action(async () => {
-    await runServer();
+  .option(
+    "--readonly",
+    "Enable read-only mode (only read operations are available)",
+    false,
+  )
+  .action(async (options: { readonly: boolean }) => {
+    await runServer(options.readonly);
   });
 
 await program.parseAsync();

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -11,7 +11,11 @@ import {
   UpdatePostParamsSchema,
 } from "../../lib/esa/types.js";
 
-export function registerTools(server: McpServer, esa: Esa) {
+export function registerTools(
+  server: McpServer,
+  esa: Esa,
+  options: { readonly: boolean },
+) {
   server.tool(
     "get_posts",
     "Retrieve a list of posts from the esa team. Supports search queries, filtering, sorting, and pagination. Returns post metadata including title, content, tags, categories, author information, and engagement metrics (comments, stars, watches). Optionally includes comments and stargazers with the include parameter. Supports nested inclusion like 'comments,comments.stargazers'.",
@@ -38,32 +42,34 @@ export function registerTools(server: McpServer, esa: Esa) {
     },
   );
 
-  server.tool(
-    "create_post",
-    "Create a new post in the esa team. Requires a title and optionally accepts content, tags, category, WIP status, and other metadata. Returns the created post information including the assigned post number and URL.",
-    CreatePostParamsSchema.shape,
-    async (params) => {
-      const post = await esa.createPost(params);
+  // Write operations - only available when not in readonly mode
+  if (!options.readonly) {
+    server.tool(
+      "create_post",
+      "Create a new post in the esa team. Requires a title and optionally accepts content, tags, category, WIP status, and other metadata. Returns the created post information including the assigned post number and URL.",
+      CreatePostParamsSchema.shape,
+      async (params) => {
+        const post = await esa.createPost(params);
 
-      return {
-        content: [{ type: "text", text: JSON.stringify(post) }],
-      };
-    },
-  );
+        return {
+          content: [{ type: "text", text: JSON.stringify(post) }],
+        };
+      },
+    );
 
-  server.tool(
-    "update_post",
-    "Update an existing post in the esa team. Requires a post number and optionally accepts updated content, tags, category, WIP status, and other metadata. Returns the updated post information.",
-    UpdatePostParamsSchema.shape,
-    async (params) => {
-      const post = await esa.updatePost(params);
+    server.tool(
+      "update_post",
+      "Update an existing post in the esa team. Requires a post number and optionally accepts updated content, tags, category, WIP status, and other metadata. Returns the updated post information.",
+      UpdatePostParamsSchema.shape,
+      async (params) => {
+        const post = await esa.updatePost(params);
 
-      return {
-        content: [{ type: "text", text: JSON.stringify(post) }],
-      };
-    },
-  );
-
+        return {
+          content: [{ type: "text", text: JSON.stringify(post) }],
+        };
+      },
+    );
+  }
   server.tool(
     "get_tags",
     "Get a list of all tags used in the esa team. Returns tags with their names and the number of posts they are attached to, sorted by post count in descending order. Supports pagination.",
@@ -77,23 +83,26 @@ export function registerTools(server: McpServer, esa: Esa) {
     },
   );
 
-  server.tool(
-    "delete_post",
-    "Delete an existing post from the esa team. Requires a post number. The post will be permanently deleted and cannot be recovered.",
-    DeletePostParamsSchema.shape,
-    async (params) => {
-      await esa.deletePost(params);
+  // Delete operation - only available when not in readonly mode
+  if (!options.readonly) {
+    server.tool(
+      "delete_post",
+      "Delete an existing post from the esa team. Requires a post number. The post will be permanently deleted and cannot be recovered.",
+      DeletePostParamsSchema.shape,
+      async (params) => {
+        await esa.deletePost(params);
 
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Post #${params.post_number} has been successfully deleted.`,
-          },
-        ],
-      };
-    },
-  );
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Post #${params.post_number} has been successfully deleted.`,
+            },
+          ],
+        };
+      },
+    );
+  }
 
   server.tool(
     "get_post_comments",
@@ -108,16 +117,19 @@ export function registerTools(server: McpServer, esa: Esa) {
     },
   );
 
-  server.tool(
-    "create_post_comment",
-    "Create a new comment on an existing post in the esa team. Requires a post number and comment content in Markdown format. Returns the created comment information including ID, content, timestamps, and author details.",
-    CreatePostCommentParamsSchema.shape,
-    async (params) => {
-      const comment = await esa.createPostComment(params);
+  // Comment creation - only available when not in readonly mode
+  if (!options.readonly) {
+    server.tool(
+      "create_post_comment",
+      "Create a new comment on an existing post in the esa team. Requires a post number and comment content in Markdown format. Returns the created comment information including ID, content, timestamps, and author details.",
+      CreatePostCommentParamsSchema.shape,
+      async (params) => {
+        const comment = await esa.createPostComment(params);
 
-      return {
-        content: [{ type: "text", text: JSON.stringify(comment) }],
-      };
-    },
-  );
+        return {
+          content: [{ type: "text", text: JSON.stringify(comment) }],
+        };
+      },
+    );
+  }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,7 +4,7 @@ import packageJson from "../package.json" with { type: "json" };
 import { Esa } from "./lib/esa";
 import { registerTools } from "./mcp/tools";
 
-export async function runServer() {
+export async function runServer(readonly: boolean) {
   const team = process.env.ESA_TEAM;
   const accessToken = process.env.ESA_ACCESS_TOKEN;
   if (!team || !accessToken) {
@@ -23,7 +23,7 @@ export async function runServer() {
   });
 
   // Register tools
-  registerTools(server, esa);
+  registerTools(server, esa, { readonly });
 
   // Start server
   const transport = new StdioServerTransport();


### PR DESCRIPTION
## Summary
- Added Commander CLI interface to the entry point
- Implemented `--readonly` flag to enable read-only mode that restricts available tools to read operations only
- Updated documentation with usage examples

## Changes
- **CLI Enhancement**: Replaced simple function call with commander-based CLI that provides `--help` and `--version` options
- **Read-only Mode**: Added `--readonly` flag that when enabled, only allows read operations:
  - Available: `get_posts`, `get_post`, `get_tags`, `get_post_comments`
  - Disabled: `create_post`, `update_post`, `delete_post`, `create_post_comment`
- **Documentation**: Updated README.md and CLAUDE.md with configuration examples for both normal and read-only modes

## Docker Usage
Normal mode:
```json
{
  "mcpServers": {
    "esa": {
      "command": "docker",
      "args": [
        "run", "-i", "--rm",
        "-e", "ESA_TEAM=<team>",
        "-e", "ESA_ACCESS_TOKEN=<token>",
        "ghcr.io/koki-develop/esa-mcp-server:latest"
      ]
    }
  }
}
```

Read-only mode:
```json
{
  "mcpServers": {
    "esa-readonly": {
      "command": "docker",
      "args": [
        "run", "-i", "--rm",
        "-e", "ESA_TEAM=<team>",
        "-e", "ESA_ACCESS_TOKEN=<token>",
        "ghcr.io/koki-develop/esa-mcp-server:latest",
        "--readonly"
      ]
    }
  }
}
```

## Test plan
- [x] Build and type checking passes
- [x] CLI help shows the `--readonly` option
- [x] Normal mode provides all tools
- [x] Read-only mode restricts to read operations only
- [x] Docker configuration examples work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)