### PR TITLE
feat: Add update_comment MCP tool for esa.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ In read-only mode, only the following operations are available:
 - `get_tags` - retrieve tags
 - `get_post_comments` - retrieve post comments
 
-Write operations (`create_post`, `update_post`, `delete_post`, `create_post_comment`) are disabled.
+Write operations (`create_post`, `update_post`, `delete_post`, `create_post_comment`, `update_comment`) are disabled.
 
 ## MCP Tools
 
@@ -97,6 +97,7 @@ Write operations (`create_post`, `update_post`, `delete_post`, `create_post_comm
 - [Comments](#comments)
   - [`get_post_comments`](#get_post_comments)
   - [`create_post_comment`](#create_post_comment)
+  - [`update_comment`](#update_comment)
 
 ### Posts
 
@@ -135,6 +136,11 @@ Retrieve a list of comments for a specific post from the esa team. Requires a po
 #### `create_post_comment`
 
 Create a new comment on an existing post in the esa team. Requires a post number and comment content in Markdown format. Returns the created comment information including ID, content, timestamps, and author details.
+
+#### `update_comment`
+
+Update an existing comment on a post in the esa team. Requires a comment ID and new content in Markdown format. Returns the updated comment information including content, timestamps, and author details.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](./LICENSE) file for details.

--- a/src/lib/esa/index.ts
+++ b/src/lib/esa/index.ts
@@ -19,6 +19,9 @@ import {
   type GetTagsParams,
   type GetTagsResponse,
   GetTagsResponseSchema,
+  type UpdateCommentParams,
+  type UpdateCommentResponse,
+  UpdateCommentResponseSchema,
   type UpdatePostParams,
   type UpdatePostResponse,
   UpdatePostResponseSchema,
@@ -123,6 +126,20 @@ export class Esa {
 
     const data = await response.json();
     return CreatePostCommentResponseSchema.parse(data);
+  }
+
+  async updateComment(
+    params: UpdateCommentParams,
+  ): Promise<UpdateCommentResponse> {
+    const { comment_id, ...commentParams } = params;
+    const response = await this._request({
+      path: `/v1/teams/${this._teamName}/comments/${comment_id}`,
+      method: "PATCH",
+      body: { comment: commentParams },
+    });
+
+    const data = await response.json();
+    return UpdateCommentResponseSchema.parse(data);
   }
   private async _request(params: {
     path: string;

--- a/src/lib/esa/types.ts
+++ b/src/lib/esa/types.ts
@@ -234,6 +234,16 @@ export const CreatePostCommentParamsSchema = z.object({
 });
 
 export const CreatePostCommentResponseSchema = CommentSchema;
+
+export const UpdateCommentParamsSchema = z.object({
+  comment_id: z.number().min(1).describe("Comment ID to update (required)."),
+  body_md: z
+    .string()
+    .min(1)
+    .describe("Updated comment content in Markdown format (required)."),
+});
+
+export const UpdateCommentResponseSchema = CommentSchema;
 export type User = z.infer<typeof UserSchema>;
 export type Post = z.infer<typeof PostSchema>;
 export type Comment = z.infer<typeof CommentSchema>;
@@ -289,3 +299,5 @@ export type CreatePostCommentParams = z.infer<
 export type CreatePostCommentResponse = z.infer<
   typeof CreatePostCommentResponseSchema
 >;
+export type UpdateCommentParams = z.infer<typeof UpdateCommentParamsSchema>;
+export type UpdateCommentResponse = z.infer<typeof UpdateCommentResponseSchema>;

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -8,6 +8,7 @@ import {
   GetPostParamsSchema,
   GetPostsParamsSchema,
   GetTagsParamsSchema,
+  UpdateCommentParamsSchema,
   UpdatePostParamsSchema,
 } from "../../lib/esa/types.js";
 
@@ -125,6 +126,19 @@ export function registerTools(
       CreatePostCommentParamsSchema.shape,
       async (params) => {
         const comment = await esa.createPostComment(params);
+
+        return {
+          content: [{ type: "text", text: JSON.stringify(comment) }],
+        };
+      },
+    );
+
+    server.tool(
+      "update_comment",
+      "Update an existing comment on a post in the esa team. Requires a comment ID and new content in Markdown format. Returns the updated comment information including content, timestamps, and author details.",
+      UpdateCommentParamsSchema.shape,
+      async (params) => {
+        const comment = await esa.updateComment(params);
 
         return {
           content: [{ type: "text", text: JSON.stringify(comment) }],


### PR DESCRIPTION
## Summary
- Add `update_comment` MCP tool to enable updating existing comments on posts
- Implement complete API client support for PATCH `/v1/teams/:team_name/comments/:comment_id` endpoint
- Add proper schema validation and type safety with Zod

## Implementation Details
- **API Schema**: Added `UpdateCommentParamsSchema` and `UpdateCommentResponseSchema`
- **Client Method**: Implemented `updateComment` method in Esa API client  
- **MCP Tool**: Registered `update_comment` tool (write operation, disabled in readonly mode)
- **Parameters**: Requires `comment_id` and `body_md` (Markdown content)
- **Response**: Returns updated comment with timestamps and author details

## Test Plan
- [x] TypeScript type checking passes
- [x] Biome linting passes  
- [x] Build succeeds
- [x] Tool follows existing patterns for MCP registration
- [x] Proper error handling with Zod schema validation
- [x] Integration with readonly mode flag

🤖 Generated with [Claude Code](https://claude.ai/code)