### PR TITLE
feat: Add delete_comment MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ In read-only mode, only the following operations are available:
 - `get_tags` - retrieve tags
 - `get_post_comments` - retrieve post comments
 
-Write operations (`create_post`, `update_post`, `delete_post`, `create_post_comment`, `update_comment`) are disabled.
+Write operations (`create_post`, `update_post`, `delete_post`, `create_post_comment`, `update_comment`, `delete_comment`) are disabled.
 
 ## MCP Tools
 
@@ -98,6 +98,7 @@ Write operations (`create_post`, `update_post`, `delete_post`, `create_post_comm
   - [`get_post_comments`](#get_post_comments)
   - [`create_post_comment`](#create_post_comment)
   - [`update_comment`](#update_comment)
+  - [`delete_comment`](#delete_comment)
 
 ### Posts
 
@@ -141,6 +142,9 @@ Create a new comment on an existing post in the esa team. Requires a post number
 
 Update an existing comment on a post in the esa team. Requires a comment ID and new content in Markdown format. Returns the updated comment information including content, timestamps, and author details.
 
+#### `delete_comment`
+
+Delete an existing comment from the esa team. Requires a comment ID. The comment will be permanently deleted and cannot be recovered. Returns a confirmation message upon successful deletion.
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](./LICENSE) file for details.

--- a/src/lib/esa/index.ts
+++ b/src/lib/esa/index.ts
@@ -6,6 +6,7 @@ import {
   type CreatePostParams,
   type CreatePostResponse,
   CreatePostResponseSchema,
+  type DeleteCommentParams,
   type DeletePostParams,
   type GetPostCommentsParams,
   type GetPostCommentsResponse,
@@ -140,6 +141,13 @@ export class Esa {
 
     const data = await response.json();
     return UpdateCommentResponseSchema.parse(data);
+  }
+
+  async deleteComment(params: DeleteCommentParams): Promise<void> {
+    await this._request({
+      path: `/v1/teams/${this._teamName}/comments/${params.comment_id}`,
+      method: "DELETE",
+    });
   }
   private async _request(params: {
     path: string;

--- a/src/lib/esa/types.ts
+++ b/src/lib/esa/types.ts
@@ -194,6 +194,10 @@ export const DeletePostParamsSchema = z.object({
   post_number: z.number().min(1).describe("Post number to delete (required)."),
 });
 
+export const DeleteCommentParamsSchema = z.object({
+  comment_id: z.number().min(1).describe("Comment ID to delete (required)."),
+});
+
 export const GetPostCommentsParamsSchema = z.object({
   post_number: z
     .number()
@@ -293,6 +297,7 @@ export type CreatePostResponse = z.infer<typeof CreatePostResponseSchema>;
 export type UpdatePostParams = z.infer<typeof UpdatePostParamsSchema>;
 export type UpdatePostResponse = z.infer<typeof UpdatePostResponseSchema>;
 export type DeletePostParams = z.infer<typeof DeletePostParamsSchema>;
+export type DeleteCommentParams = z.infer<typeof DeleteCommentParamsSchema>;
 export type CreatePostCommentParams = z.infer<
   typeof CreatePostCommentParamsSchema
 >;

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -3,6 +3,7 @@ import type { Esa } from "../../lib/esa/index.js";
 import {
   CreatePostCommentParamsSchema,
   CreatePostParamsSchema,
+  DeleteCommentParamsSchema,
   DeletePostParamsSchema,
   GetPostCommentsParamsSchema,
   GetPostParamsSchema,
@@ -142,6 +143,24 @@ export function registerTools(
 
         return {
           content: [{ type: "text", text: JSON.stringify(comment) }],
+        };
+      },
+    );
+
+    server.tool(
+      "delete_comment",
+      "Delete an existing comment from the esa team. Requires a comment ID. The comment will be permanently deleted and cannot be recovered.",
+      DeleteCommentParamsSchema.shape,
+      async (params) => {
+        await esa.deleteComment(params);
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Comment #${params.comment_id} has been successfully deleted.`,
+            },
+          ],
         };
       },
     );


### PR DESCRIPTION
## Summary

This PR introduces the `delete_comment` MCP tool that allows users to delete comments through the Model Context Protocol interface.

## Changes

- **API Client Enhancement**: Added `deleteComment` method to the `Esa` class in `src/lib/esa/index.ts`
- **Type Definitions**: Added `DeleteCommentParamsSchema` and `DeleteCommentParams` type definitions in `src/lib/esa/types.ts`
- **MCP Tool Registration**: Added `delete_comment` tool registration in `src/mcp/tools/index.ts`
- **Documentation**: Updated README.md to document the new `delete_comment` tool functionality

## Implementation Details

- Follows the same architectural pattern as the existing `delete_post` tool
- Uses the esa.io API endpoint: `DELETE /v1/teams/:team_name/comments/:comment_id`
- Requires `comment_id` parameter (number, minimum 1)
- Returns a confirmation message upon successful deletion
- Only available when not in readonly mode (consistent with other write operations)
- Includes proper TypeScript type safety and Zod schema validation

## Test Plan

- [x] TypeScript compilation passes
- [x] Code linting passes (Biome)
- [x] Build process completes successfully
- [x] Follows existing code patterns and conventions

## API Usage

The tool can be used to delete comments by providing the comment ID:

```json
{
  "comment_id": 12345
}
```

The API will respond with a confirmation message indicating successful deletion.

🤖 Generated with [Claude Code](https://claude.ai/code)